### PR TITLE
Add JPA layers and basic CRUD controllers

### DIFF
--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/controller/AddressController.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/controller/AddressController.java
@@ -1,0 +1,46 @@
+package com.neodain.springbootbatchdemo.controller;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+import com.neodain.springbootbatchdemo.entity.AddressDto.AddressRequest;
+import com.neodain.springbootbatchdemo.entity.AddressDto.AddressResponse;
+import com.neodain.springbootbatchdemo.service.AddressService;
+
+@RestController
+@RequestMapping("/addresses")
+@RequiredArgsConstructor
+public class AddressController {
+
+    private final AddressService service;
+
+    @PostMapping("/member/{memberId}")
+    public ResponseEntity<AddressResponse> create(@PathVariable String memberId,
+                                                  @RequestBody AddressRequest request) {
+        return ResponseEntity.ok(service.create(memberId, request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AddressResponse> get(@PathVariable Long id) {
+        return ResponseEntity.ok(service.get(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AddressResponse>> getAll() {
+        return ResponseEntity.ok(service.getAll());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<AddressResponse> update(@PathVariable Long id,
+                                                  @RequestBody AddressRequest request) {
+        return ResponseEntity.ok(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/controller/DevopsController.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/controller/DevopsController.java
@@ -1,0 +1,45 @@
+package com.neodain.springbootbatchdemo.controller;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+import com.neodain.springbootbatchdemo.entity.DevopsDto.DevopsRequest;
+import com.neodain.springbootbatchdemo.entity.DevopsDto.DevopsResponse;
+import com.neodain.springbootbatchdemo.service.DevopsService;
+
+@RestController
+@RequestMapping("/devops")
+@RequiredArgsConstructor
+public class DevopsController {
+
+    private final DevopsService service;
+
+    @PostMapping
+    public ResponseEntity<DevopsResponse> create(@RequestBody DevopsRequest request) {
+        return ResponseEntity.ok(service.create(request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DevopsResponse> get(@PathVariable("id") String id) {
+        return ResponseEntity.ok(service.get(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<DevopsResponse>> getAll() {
+        return ResponseEntity.ok(service.getAll());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<DevopsResponse> update(@PathVariable("id") String id,
+                                                 @RequestBody DevopsRequest request) {
+        return ResponseEntity.ok(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable("id") String id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/controller/DevopsMemberController.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/controller/DevopsMemberController.java
@@ -1,0 +1,45 @@
+package com.neodain.springbootbatchdemo.controller;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+import com.neodain.springbootbatchdemo.entity.MemberDto.MemberRequest;
+import com.neodain.springbootbatchdemo.entity.MemberDto.MemberResponse;
+import com.neodain.springbootbatchdemo.service.DevopsMemberService;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class DevopsMemberController {
+
+    private final DevopsMemberService service;
+
+    @PostMapping
+    public ResponseEntity<MemberResponse> create(@RequestBody MemberRequest request) {
+        return ResponseEntity.ok(service.create(request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MemberResponse> get(@PathVariable("id") String id) {
+        return ResponseEntity.ok(service.get(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MemberResponse>> getAll() {
+        return ResponseEntity.ok(service.getAll());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MemberResponse> update(@PathVariable("id") String id,
+                                                 @RequestBody MemberRequest request) {
+        return ResponseEntity.ok(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable("id") String id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/controller/DevopsMembershipController.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/controller/DevopsMembershipController.java
@@ -1,0 +1,49 @@
+package com.neodain.springbootbatchdemo.controller;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+import com.neodain.springbootbatchdemo.entity.DevopsMembership.DevopsMembershipId;
+import com.neodain.springbootbatchdemo.entity.MembershipDto.MembershipRequest;
+import com.neodain.springbootbatchdemo.entity.MembershipDto.MembershipResponse;
+import com.neodain.springbootbatchdemo.service.DevopsMembershipService;
+
+@RestController
+@RequestMapping("/memberships")
+@RequiredArgsConstructor
+public class DevopsMembershipController {
+
+    private final DevopsMembershipService service;
+
+    @PostMapping
+    public ResponseEntity<MembershipResponse> create(@RequestBody MembershipRequest request) {
+        return ResponseEntity.ok(service.create(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MembershipResponse>> getAll() {
+        return ResponseEntity.ok(service.getAll());
+    }
+
+    @GetMapping("/{devopsId}/{memberId}")
+    public ResponseEntity<MembershipResponse> get(@PathVariable String devopsId,
+                                                  @PathVariable String memberId) {
+        return ResponseEntity.ok(service.get(new DevopsMembershipId(devopsId, memberId)));
+    }
+
+    @PutMapping("/{devopsId}/{memberId}")
+    public ResponseEntity<MembershipResponse> update(@PathVariable String devopsId,
+                                                     @PathVariable String memberId,
+                                                     @RequestBody MembershipRequest request) {
+        return ResponseEntity.ok(service.update(new DevopsMembershipId(devopsId, memberId), request));
+    }
+
+    @DeleteMapping("/{devopsId}/{memberId}")
+    public ResponseEntity<Void> delete(@PathVariable String devopsId,
+                                       @PathVariable String memberId) {
+        service.delete(new DevopsMembershipId(devopsId, memberId));
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/repository/AddressRepository.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/repository/AddressRepository.java
@@ -1,0 +1,7 @@
+package com.neodain.springbootbatchdemo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.neodain.springbootbatchdemo.entity.Address;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/repository/DevopsMemberRepository.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/repository/DevopsMemberRepository.java
@@ -1,0 +1,7 @@
+package com.neodain.springbootbatchdemo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.neodain.springbootbatchdemo.entity.DevopsMember;
+
+public interface DevopsMemberRepository extends JpaRepository<DevopsMember, String> {
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/repository/DevopsMembershipRepository.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/repository/DevopsMembershipRepository.java
@@ -1,0 +1,7 @@
+package com.neodain.springbootbatchdemo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.neodain.springbootbatchdemo.entity.DevopsMembership;
+
+public interface DevopsMembershipRepository extends JpaRepository<DevopsMembership, DevopsMembership.DevopsMembershipId> {
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/repository/DevopsRepository.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/repository/DevopsRepository.java
@@ -1,0 +1,7 @@
+package com.neodain.springbootbatchdemo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.neodain.springbootbatchdemo.entity.Devops;
+
+public interface DevopsRepository extends JpaRepository<Devops, String> {
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/AddressService.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/AddressService.java
@@ -1,0 +1,13 @@
+package com.neodain.springbootbatchdemo.service;
+
+import java.util.List;
+import com.neodain.springbootbatchdemo.entity.AddressDto.AddressRequest;
+import com.neodain.springbootbatchdemo.entity.AddressDto.AddressResponse;
+
+public interface AddressService {
+    AddressResponse create(String memberId, AddressRequest request);
+    AddressResponse get(Long id);
+    List<AddressResponse> getAll();
+    AddressResponse update(Long id, AddressRequest request);
+    void delete(Long id);
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/DevopsMemberService.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/DevopsMemberService.java
@@ -1,0 +1,13 @@
+package com.neodain.springbootbatchdemo.service;
+
+import java.util.List;
+import com.neodain.springbootbatchdemo.entity.MemberDto.MemberRequest;
+import com.neodain.springbootbatchdemo.entity.MemberDto.MemberResponse;
+
+public interface DevopsMemberService {
+    MemberResponse create(MemberRequest request);
+    MemberResponse get(String memberId);
+    List<MemberResponse> getAll();
+    MemberResponse update(String memberId, MemberRequest request);
+    void delete(String memberId);
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/DevopsMembershipService.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/DevopsMembershipService.java
@@ -1,0 +1,14 @@
+package com.neodain.springbootbatchdemo.service;
+
+import java.util.List;
+import com.neodain.springbootbatchdemo.entity.MembershipDto.MembershipRequest;
+import com.neodain.springbootbatchdemo.entity.MembershipDto.MembershipResponse;
+import com.neodain.springbootbatchdemo.entity.DevopsMembership.DevopsMembershipId;
+
+public interface DevopsMembershipService {
+    MembershipResponse create(MembershipRequest request);
+    MembershipResponse get(DevopsMembershipId id);
+    List<MembershipResponse> getAll();
+    MembershipResponse update(DevopsMembershipId id, MembershipRequest request);
+    void delete(DevopsMembershipId id);
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/DevopsService.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/DevopsService.java
@@ -1,0 +1,13 @@
+package com.neodain.springbootbatchdemo.service;
+
+import java.util.List;
+import com.neodain.springbootbatchdemo.entity.DevopsDto.DevopsRequest;
+import com.neodain.springbootbatchdemo.entity.DevopsDto.DevopsResponse;
+
+public interface DevopsService {
+    DevopsResponse create(DevopsRequest request);
+    DevopsResponse get(String devopsId);
+    List<DevopsResponse> getAll();
+    DevopsResponse update(String devopsId, DevopsRequest request);
+    void delete(String devopsId);
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/impl/AddressServiceImpl.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/impl/AddressServiceImpl.java
@@ -1,0 +1,87 @@
+package com.neodain.springbootbatchdemo.service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import com.neodain.springbootbatchdemo.entity.Address;
+import com.neodain.springbootbatchdemo.entity.AddressDto.AddressRequest;
+import com.neodain.springbootbatchdemo.entity.AddressDto.AddressResponse;
+import com.neodain.springbootbatchdemo.entity.DevopsMember;
+import com.neodain.springbootbatchdemo.repository.AddressRepository;
+import com.neodain.springbootbatchdemo.repository.DevopsMemberRepository;
+import com.neodain.springbootbatchdemo.service.AddressService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AddressServiceImpl implements AddressService {
+
+    private final AddressRepository repository;
+    private final DevopsMemberRepository memberRepository;
+
+    @Override
+    public AddressResponse create(String memberId, AddressRequest request) {
+        DevopsMember member = memberRepository.findById(memberId).orElse(null);
+        if (member == null) {
+            return null;
+        }
+        Address address = Address.builder()
+                .member(member)
+                .type(request.addressType())
+                .addressLine(request.addressLine())
+                .city(request.city())
+                .state(request.state())
+                .zipCode(request.zipCode())
+                .build();
+        repository.save(address);
+        return toResponse(address);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AddressResponse get(Long id) {
+        return repository.findById(id)
+                .map(this::toResponse)
+                .orElse(null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AddressResponse> getAll() {
+        return repository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public AddressResponse update(Long id, AddressRequest request) {
+        return repository.findById(id)
+                .map(entity -> {
+                    entity.setType(request.addressType());
+                    entity.setAddressLine(request.addressLine());
+                    entity.setCity(request.city());
+                    entity.setState(request.state());
+                    entity.setZipCode(request.zipCode());
+                    return toResponse(repository.save(entity));
+                }).orElse(null);
+    }
+
+    @Override
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    private AddressResponse toResponse(Address address) {
+        return new AddressResponse(
+                address.getId(),
+                address.getType(),
+                address.getAddressLine(),
+                address.getCity(),
+                address.getState(),
+                address.getZipCode());
+    }
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/impl/DevopsMemberServiceImpl.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/impl/DevopsMemberServiceImpl.java
@@ -1,0 +1,90 @@
+package com.neodain.springbootbatchdemo.service.impl;
+
+import java.sql.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import com.neodain.springbootbatchdemo.entity.DevopsMember;
+import com.neodain.springbootbatchdemo.entity.MemberDto.MemberRequest;
+import com.neodain.springbootbatchdemo.entity.MemberDto.MemberResponse;
+import com.neodain.springbootbatchdemo.repository.DevopsMemberRepository;
+import com.neodain.springbootbatchdemo.service.DevopsMemberService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DevopsMemberServiceImpl implements DevopsMemberService {
+
+    private final DevopsMemberRepository repository;
+
+    @Override
+    public MemberResponse create(MemberRequest request) {
+        DevopsMember member = DevopsMember.builder()
+                .memberId(UUID.randomUUID().toString())
+                .name(request.name())
+                .nickname(request.nickname())
+                .gender(request.gender())
+                .birthday(parseDate(request.birthday()))
+                .phoneNum(request.phoneNum())
+                .email(request.email())
+                .build();
+        repository.save(member);
+        return toResponse(member);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberResponse get(String memberId) {
+        return repository.findById(memberId)
+                .map(this::toResponse)
+                .orElse(null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MemberResponse> getAll() {
+        return repository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public MemberResponse update(String memberId, MemberRequest request) {
+        return repository.findById(memberId)
+                .map(entity -> {
+                    entity.setName(request.name());
+                    entity.setNickname(request.nickname());
+                    entity.setGender(request.gender());
+                    entity.setBirthday(parseDate(request.birthday()));
+                    entity.setPhoneNum(request.phoneNum());
+                    entity.setEmail(request.email());
+                    return toResponse(repository.save(entity));
+                }).orElse(null);
+    }
+
+    @Override
+    public void delete(String memberId) {
+        repository.deleteById(memberId);
+    }
+
+    private MemberResponse toResponse(DevopsMember member) {
+        String birthStr = member.getBirthday() != null ? member.getBirthday().toString() : null;
+        return new MemberResponse(
+                member.getMemberId(),
+                member.getName(),
+                member.getNickname(),
+                member.getGender(),
+                birthStr,
+                member.getPhoneNum(),
+                member.getEmail());
+    }
+
+    private Date parseDate(String value) {
+        return (value == null || value.isEmpty()) ? null : Date.valueOf(value);
+    }
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/impl/DevopsMembershipServiceImpl.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/impl/DevopsMembershipServiceImpl.java
@@ -1,0 +1,78 @@
+package com.neodain.springbootbatchdemo.service.impl;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import com.neodain.springbootbatchdemo.entity.DevopsMembership;
+import com.neodain.springbootbatchdemo.entity.DevopsMembership.Role;
+import com.neodain.springbootbatchdemo.entity.DevopsMembership.DevopsMembershipId;
+import com.neodain.springbootbatchdemo.entity.MembershipDto.MembershipRequest;
+import com.neodain.springbootbatchdemo.entity.MembershipDto.MembershipResponse;
+import com.neodain.springbootbatchdemo.repository.DevopsMembershipRepository;
+import com.neodain.springbootbatchdemo.service.DevopsMembershipService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DevopsMembershipServiceImpl implements DevopsMembershipService {
+
+    private final DevopsMembershipRepository repository;
+
+    @Override
+    public MembershipResponse create(MembershipRequest request) {
+        DevopsMembership membership = DevopsMembership.builder()
+                .devopsId(request.devopsId())
+                .memberId(request.memberId())
+                .role(Role.beginner)
+                .joinDate(LocalDate.now())
+                .build();
+        repository.save(membership);
+        return toResponse(membership);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MembershipResponse get(DevopsMembershipId id) {
+        return repository.findById(id)
+                .map(this::toResponse)
+                .orElse(null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MembershipResponse> getAll() {
+        return repository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public MembershipResponse update(DevopsMembershipId id, MembershipRequest request) {
+        return repository.findById(id)
+                .map(entity -> {
+                    entity.setDevopsId(request.devopsId());
+                    entity.setMemberId(request.memberId());
+                    return toResponse(repository.save(entity));
+                }).orElse(null);
+    }
+
+    @Override
+    public void delete(DevopsMembershipId id) {
+        repository.deleteById(id);
+    }
+
+    private MembershipResponse toResponse(DevopsMembership membership) {
+        return new MembershipResponse(
+                membership.getMemberId(),
+                null,
+                null,
+                null,
+                membership.getRole(),
+                membership.getJoinDate().atStartOfDay());
+    }
+}

--- a/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/impl/DevopsServiceImpl.java
+++ b/SpringBootBatchDemo/src/main/java/com/neodain/springbootbatchdemo/service/impl/DevopsServiceImpl.java
@@ -1,0 +1,75 @@
+package com.neodain.springbootbatchdemo.service.impl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import com.neodain.springbootbatchdemo.entity.Devops;
+import com.neodain.springbootbatchdemo.entity.DevopsDto.DevopsRequest;
+import com.neodain.springbootbatchdemo.entity.DevopsDto.DevopsResponse;
+import com.neodain.springbootbatchdemo.repository.DevopsRepository;
+import com.neodain.springbootbatchdemo.service.DevopsService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DevopsServiceImpl implements DevopsService {
+
+    private final DevopsRepository repository;
+
+    @Override
+    public DevopsResponse create(DevopsRequest request) {
+        Devops devops = Devops.builder()
+                .devopsId(UUID.randomUUID().toString())
+                .name(request.name())
+                .intro(request.intro())
+                .foundationTime(LocalDateTime.now())
+                .build();
+        repository.save(devops);
+        return toResponse(devops);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DevopsResponse get(String devopsId) {
+        return repository.findById(devopsId)
+                .map(this::toResponse)
+                .orElse(null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DevopsResponse> getAll() {
+        return repository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public DevopsResponse update(String devopsId, DevopsRequest request) {
+        return repository.findById(devopsId)
+                .map(entity -> {
+                    entity.setName(request.name());
+                    entity.setIntro(request.intro());
+                    return toResponse(repository.save(entity));
+                }).orElse(null);
+    }
+
+    @Override
+    public void delete(String devopsId) {
+        repository.deleteById(devopsId);
+    }
+
+    private DevopsResponse toResponse(Devops devops) {
+        return new DevopsResponse(
+                devops.getDevopsId(),
+                devops.getName(),
+                devops.getIntro(),
+                devops.getFoundationTime());
+    }
+}


### PR DESCRIPTION
## Summary
- add repository interfaces for all entities
- define service contracts and implementations
- create REST controllers with CRUD endpoints

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68433ab08f3483309398ee7a2e802b81